### PR TITLE
アイテムのindexの実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,10 @@
 class ItemsController < ApplicationController
   before_action :get_item, only: %i(edit show update destroy)
 
+  def index
+    @items = Item.order('updated_at DESC')
+  end
+
   def new
     @item = Item.new
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,0 +1,12 @@
+<%= render "shared/header" %>
+
+<div class="container">
+
+    <main role="main" class="item-index-container-inner">
+
+        <h4 class="title">アイテム一覧</h4>
+
+        <%= render "shared/basic-content" %>
+
+    </main>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,9 @@ Rails.application.routes.draw do
   resources :orders,             only: :index
   resources :kitchen_orders,     only: :index
   resources :people_managements, only: %i(edit update)
-  resources :items,              only: %i(new create edit show update destroy)
+  resources :items,              only: %i(index new create edit show update destroy)
   resources :usage_of_apps, only: :index
 
   get 'search' => 'foods#search'
+  get 'bevsearch' => 'beverages#search'
 end


### PR DESCRIPTION
アイテム登録失敗時、renderingされた後に画面をリロードするとエラーになってしまうので、それを防ぐためにitem全体のindex画面を作ることにした。